### PR TITLE
src/main.c: add a header file for fixing a build warning

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -125,6 +125,8 @@
 #include <string.h>
 #include <signal.h>
 
+#include <unistd.h>
+
 #ifdef ANDROID
 #include <cutils/properties.h>
 #define LOG_TAG "brcm_patchram_plus"


### PR DESCRIPTION
Fix the problem like:
main.c:744:2: warning: implicit declaration of function ‘write’;
did you mean ‘fwrite’? [-Wimplicit-functio   ]

Signed-off-by: Wei Fu <tekkamanninja@gmail.com>